### PR TITLE
Prepend forward slash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-node_modules/
-lib/
+/node_modules/
+/lib/


### PR DESCRIPTION
I suggest checking for root level folders, as you might end up having more than one `node_modules`, or perhaps another `lib` folder that shouldn't be ignored.  You can always change that yourself at whatever point, so this is minor in the suggestion queue.
